### PR TITLE
Pin FirebaseExtended/action-hosting-deploy to full commit SHA

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -57,7 +57,7 @@ jobs:
           make docs
           make gen-prod
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_QA }}'


### PR DESCRIPTION
Pins the last remaining unpinned GitHub Action to a full-length commit SHA, matching the hardening applied to the other workflows in #27.

`FirebaseExtended/action-hosting-deploy@v0` was still referencing a moving tag. The `v0` tag currently resolves to `500ac625ca2dd40cbd15f7659af953801858032a` (identical to the `v0.11.0` release), which is now pinned explicitly.

All actions across the four workflow files are now pinned to full commit SHAs.