### PR TITLE
Grant preview-website job checks:write permission

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
The `FirebaseExtended/action-hosting-deploy` action creates a check run and PR comment. After the workflow hardening in #27, the default `GITHUB_TOKEN` became read-only, so the action failed with a 403 `Resource not accessible by integration` when calling `POST /check-runs` (the response's `x-accepted-github-permissions` header requires `checks=write`).

This grants the `build` job the permissions the action needs:
- `checks: write` — create the "Deploy Preview" check run
- `pull-requests: write` — post the preview URL comment
- `contents: read` — checkout

Fixes the failure in [run 28863638101](https://github.com/kubeguard/website/actions/runs/28863638101/job/85608140460).